### PR TITLE
Fix #71

### DIFF
--- a/app/renderer/components/Button/index.js
+++ b/app/renderer/components/Button/index.js
@@ -34,7 +34,7 @@ const IconAfter = ({ iconAfter, loading, variant }) => {
 };
 
 const Button = ({ children, iconBefore, iconAfter, variant, loading, ...restProps }) => (
-  <StyledButton {...restProps} {...{ iconBefore, iconAfter, loading, variant }}>
+  <StyledButton loading={loading ? 1 : undefined} {...restProps} {...{ iconBefore, iconAfter, variant }}>
     {iconBefore && <IconWrapper>{iconBefore}</IconWrapper>}
     {children}
     {(iconAfter || loading) && <IconAfter {...{ iconAfter, loading, variant }} />}


### PR DESCRIPTION
Fixes #71 by converting Button loading attribute to non-boolean value that is not passed through by styled components library to DOM.  Error no longer appears.