### PR TITLE
fix for react state warning bug - issue #72

### DIFF
--- a/app/renderer/pages/homePage/index.js
+++ b/app/renderer/pages/homePage/index.js
@@ -51,12 +51,19 @@ const HomePage = ({
   match,
 }) => {
   const [isShowResetSection, setIsShowResetSection] = useState(false);
-  setTimeout(() => {
-    const { path } = match;
-    if (path === ROUTES.ROOT) {
-      setIsShowResetSection(true);
-    }
-  }, 40000);
+
+  useEffect(() => {
+    const sectionResetTimer = setTimeout(() => {
+      const { path } = match;
+      if (path === ROUTES.ROOT) {
+        setIsShowResetSection(true);
+      }
+    }, 40000);
+
+    return function cleanup() {
+      clearTimeout(sectionResetTimer);
+    };
+  }, []);
 
   useEffect(() => {
     Logger.debug(`HomePage, hasBlockNumbers: ${hasBlockNumbers}`);


### PR DESCRIPTION
o Fix for issue #72 

**Steps To Reproduce Issue:**
1. Run the application via npm run dev
2. Wait for 40-50 seconds, observing the console, the warning will pop-up. 

**Expected Behavior:** State updates as expected, and cleans itself properly
**Actual Behavior:** State update is attempted on an unmounted component

**Root Cause:** When the Homepage component loads, setTimeout is set to call a function that may update the component's state after 40 seconds depending on a conditional check. 
The setIsShowResetSection method waits in the javascript thread's message queue for 40 seconds, and then when its ready to be called, if the homepage component is not mounted, an error will be thrown because setIsShowResetSection will attempt to update state on an unmounted component. 

**Resolution:** Move the setTimeout call into a useEffect function that behaves equivalently to componentDidMount, cleanup that function when the component un-mounts by cancelling the call to setTimeout. 

