### PR TITLE
Increase Api init waiting time

### DIFF
--- a/app/config/common.js
+++ b/app/config/common.js
@@ -7,7 +7,7 @@ const commonConfig = {
   // Common config shared by dev and prod comes here...
   app: {
     name: 'rUN',
-    apiInitDebounceTime: 10000, // after clean local chain data, api init need more than 6s
+    apiInitDebounceTime: 30000,
     defaultDebounceTime: 500,
     sentryDSN: 'https://0c4aa4aa53f1494e87d532890cb59529@sentry.io/1436322',
     networkOptions: [NetworkNameMapping.THENODE_RIMU, NetworkNameMapping.Development], // networkOptions[0] is the default network to be joined in, in this case, Rimu is by default to be connected.


### PR DESCRIPTION
Increased Api init timeout to 30s for now, and will refactor to start following api action once receiving `api.isReady` is called (Ticket created in backlog)